### PR TITLE
chore: remove discriminator from getDiscordUser

### DIFF
--- a/src/functions/getDiscordUser.ts
+++ b/src/functions/getDiscordUser.ts
@@ -10,7 +10,6 @@ export default async function getDiscordUser(id: string) {
 			query getUser($id: String) {
 				discordUsers(userId: $id) {
 					username
-					discriminator
 				}
 			}
 		`,


### PR DESCRIPTION
The user's `discriminator` is not needed for building the `metadata.json` file as we do not include this, however, the `id` is needed